### PR TITLE
fix: return typed error when isolated asset list is full

### DIFF
--- a/onchain/contracts/borrow/production/pool/pool-borrow.clar
+++ b/onchain/contracts/borrow/production/pool/pool-borrow.clar
@@ -921,7 +921,7 @@
     (borroweable-assets (get-borroweable-isolated)))
     (asserts! (is-configurator tx-sender) ERR_UNAUTHORIZED)
     (contract-call? .pool-0-reserve-v2-0 set-borroweable-isolated
-      (unwrap-panic (as-max-len? (append borroweable-assets asset) u100)))
+      (unwrap! (as-max-len? (append borroweable-assets asset) u100) ERR_PANIC))
   )
 )
 

--- a/onchain/tests/borrow/isolation-mode.test.ts
+++ b/onchain/tests/borrow/isolation-mode.test.ts
@@ -142,6 +142,29 @@ describe("Isolated mode", () => {
     initializeRewards(simnet, deployerAddress);
   });
 
+  it("returns a typed error when the isolated borrowable list is full", () => {
+    const poolBorrow = new PoolBorrow(
+      simnet,
+      deployerAddress,
+      config.poolBorrow
+    );
+
+    for (let index = 0; index < 100; index += 1) {
+      poolBorrow.setBorroweableIsolated(
+        deployerAddress,
+        xUSD,
+        deployerAddress
+      );
+    }
+
+    const callResponse = poolBorrow.setBorroweableIsolated(
+      deployerAddress,
+      xUSD,
+      deployerAddress
+    );
+
+    expect(callResponse.result).toBeErr(Cl.uint(30023));
+  });
   it("Supply and borrow supplying only isolated asset.", () => {
     const poolBorrow = new PoolBorrow(
       simnet,


### PR DESCRIPTION
## Summary

Replace the `unwrap-panic` in `set-borroweable-isolated` with `unwrap! ... ERR_PANIC`. When the `(list 100 principal)` is full, the function now returns the contract's existing typed error `u30023` instead of aborting with an opaque runtime panic.

## Audit provenance

This directly addresses **F-06** in the paid static-analysis report for `pool-borrow-v2-3`:
https://gist.github.com/ClankOS/81d0c60d3378a9d37dea9fafb460a06d

The report's recommendation is to replace the capacity-bound `unwrap-panic` with a typed error. The contract change is intentionally one line and does not alter successful calls or the list limit.

## Regression coverage

The added isolation-mode test fills the borrowable-isolated list to its 100-principal limit, attempts one additional insertion, and asserts the public function returns `(err u30023)`.

- Capacity below 100: `as-max-len?` returns `some`, so behavior is unchanged.
- Capacity at 100: appending produces a 101-item list, `as-max-len?` returns `none`, and `unwrap!` returns `ERR_PANIC` (`u30023`).
- No storage layout or public function signature changes.