### PR TITLE
[codex] Return ERR_PANIC instead of panicking in borrow paths

### DIFF
--- a/onchain/contracts/borrow/production/pool/pool-borrow.clar
+++ b/onchain/contracts/borrow/production/pool/pool-borrow.clar
@@ -921,7 +921,7 @@
     (borroweable-assets (get-borroweable-isolated)))
     (asserts! (is-configurator tx-sender) ERR_UNAUTHORIZED)
     (contract-call? .pool-0-reserve-v2-0 set-borroweable-isolated
-      (unwrap-panic (as-max-len? (append borroweable-assets asset) u100)))
+      (unwrap! (as-max-len? (append borroweable-assets asset) u100) ERR_PANIC))
   )
 )
 

--- a/onchain/contracts/borrow/production/pool/pool-borrow.clar
+++ b/onchain/contracts/borrow/production/pool/pool-borrow.clar
@@ -88,7 +88,7 @@
       (if (is-eq current-balance u0)
         ;; additional checks for first supply and if it's isolation mode
         (if (and (get usage-as-collateral-enabled reserve-state)
-              (unwrap-panic
+              (unwrap!
                 (validate-use-as-collateral
                   isolated-asset
                   ;; we only use base ltv, no need to fetch in case of e-mode
@@ -97,7 +97,8 @@
                   supplied-asset-principal
                   owner
                   (get debt-ceiling reserve-state)
-                ))
+                )
+                ERR_PANIC)
               (if (is-in-e-mode owner)
                 ;; if in e-mode, can only enable use-as-collateral for same e-mode type
                 (is-eq (get-asset-e-mode-type supplied-asset-principal) (get-user-e-mode owner))


### PR DESCRIPTION
## Summary

- Replace the `unwrap-panic` in `set-borroweable-isolated` with `unwrap! ... ERR_PANIC`.
- Replace the `unwrap-panic` around `validate-use-as-collateral` in `supply` with `unwrap! ... ERR_PANIC`.
- Keeps successful paths unchanged while returning contract errors for the two audit-noted failure paths instead of aborting with panic.
- References ClankOS Zest audit findings F-06 and F-07: https://gist.github.com/ClankOS/81d0c60d3378a9d37dea9fafb460a06d

## Validation

- `git diff --check`
- `clarinet check contracts/borrow/production/pool/pool-borrow.clar` passed with existing warnings only.
- Full `clarinet check --manifest-path ./Clarinet.toml` could not complete locally because the environment failed while retrieving the remote `arkadiko-dao` contract from Hiro API.

BTC payout address if this is accepted for a bounty: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`