### PR TITLE
Fix flashloan liquidation liquidity snapshot

### DIFF
--- a/onchain/contracts/borrow/production/pool/pool-borrow.clar
+++ b/onchain/contracts/borrow/production/pool/pool-borrow.clar
@@ -40,11 +40,17 @@
 (define-constant ERR_E_MODE_TYPE_MISMATCH (err u30029))
 (define-constant ERR_NO_ASSETS_USED_AS_COLLATERAL (err u30030))
 (define-constant ERR_MUST_ENABLE_ASSET_OF_E_MODE (err u30031))
+(define-constant ERR_FLASHLOAN_ALREADY_PENDING (err u30032))
+(define-constant ERR_NO_PENDING_FLASHLOAN (err u30033))
 
 
 (define-constant e-mode-disabled-type 0x00)
 
 (define-map users-id uint principal)
+
+(define-map pending-flashloan-liquidations
+  { caller: principal, receiver: principal, asset: principal, flashloan-script: principal }
+  { amount: uint, available-liquidity-before: uint })
 
 (define-data-var last-user-id uint u0)
 
@@ -557,6 +563,12 @@
     (amount-fee (/ (* amount total-fee-bps) u10000))
     (protocol-fee (/ (* amount-fee protocol-fee-bps) u10000))
     (reserve-data (try! (get-reserve-state (contract-of asset))))
+    (flashloan-key {
+      caller: contract-caller,
+      receiver: receiver,
+      asset: (contract-of asset),
+      flashloan-script: (contract-of flashloan-script)
+    })
   )
     (try! (is-approved-contract contract-caller))
     (asserts! (>= available-liquidity-before amount) ERR_EXCEEDED_LIQ)
@@ -564,6 +576,11 @@
     (asserts! (get flashloan-enabled reserve-data) ERR_FLASHLOAN_DISABLED)
     (asserts! (get is-active reserve-data) ERR_INACTIVE)
     (asserts! (not (get is-frozen reserve-data)) ERR_FROZEN)
+    (asserts!
+      (map-insert pending-flashloan-liquidations
+        flashloan-key
+        { amount: amount, available-liquidity-before: available-liquidity-before })
+      ERR_FLASHLOAN_ALREADY_PENDING)
 
     (try! (contract-call? .pool-0-reserve-v2-0 transfer-to-user asset receiver amount))
     (ok u0)
@@ -576,15 +593,21 @@
   (amount uint)
   (flashloan-script <flash-loan>))
   (let  (
-    (available-liquidity-before (try! (contract-call? .pool-0-reserve-v2-0 get-reserve-available-liquidity asset)))
     (total-fee-bps (try! (contract-call? .pool-0-reserve-v2-0 get-flashloan-fee-total (contract-of asset))))
     (protocol-fee-bps (try! (contract-call? .pool-0-reserve-v2-0 get-flashloan-fee-protocol (contract-of asset))))
     (amount-fee (/ (* amount total-fee-bps) u10000))
     (protocol-fee (/ (* amount-fee protocol-fee-bps) u10000))
     (reserve-data (try! (get-reserve-state (contract-of asset))))
+    (flashloan-key {
+      caller: contract-caller,
+      receiver: receiver,
+      asset: (contract-of asset),
+      flashloan-script: (contract-of flashloan-script)
+    })
+    (pending-flashloan (unwrap! (map-get? pending-flashloan-liquidations flashloan-key) ERR_NO_PENDING_FLASHLOAN))
   )
     (try! (is-approved-contract contract-caller))
-    (asserts! (>= available-liquidity-before amount) ERR_EXCEEDED_LIQ)
+    (asserts! (is-eq amount (get amount pending-flashloan)) ERR_INVALID_AMOUNT)
     (asserts! (and (> amount-fee u0) (> protocol-fee u0)) ERR_NOT_ZERO)
     (asserts! (get flashloan-enabled reserve-data) ERR_FLASHLOAN_DISABLED)
     (asserts! (get is-active reserve-data) ERR_INACTIVE)
@@ -599,11 +622,13 @@
       )
     )
 
+    (map-delete pending-flashloan-liquidations flashloan-key)
+
     (try!
       (contract-call? .pool-0-reserve-v2-0 update-state-on-flash-loan
         receiver
         asset
-        available-liquidity-before
+        (get available-liquidity-before pending-flashloan)
         (- amount-fee protocol-fee)
         protocol-fee
       )


### PR DESCRIPTION
## Summary
- Records the reserve liquidity snapshot during lashloan-liquidation-step-1.
- Consumes that pending snapshot in lashloan-liquidation-step-2 instead of re-reading post-withdraw liquidity.
- Keeps step 2 bound to the same approved caller, receiver, asset, flashloan script, and amount before updating flashloan reserve state.

## Audit Finding Addressed
This PR addresses **F-01** from ClankOS's paid Zest audit:

- Audit gist: https://gist.github.com/ClankOS/81d0c60d3378a9d37dea9fafb460a06d
- Finding ID: **F-01**
- Finding summary: lashloan-liquidation-step-2 reads reserve liquidity after lashloan-liquidation-step-1 has already transferred the flashloan amount out, so valid full-liquidity liquidations can revert with ERR_EXCEEDED_LIQ before repayment and reserve-state update.
- AIBTC follow-up bounty tracking shipped fixes: mqewgyvr5063fd520a70

## Rationale
lashloan-liquidation-step-2 currently calls get-reserve-available-liquidity after step-1 has already transferred the flashloan amount out of the reserve. For liquidations that legitimately borrow all available liquidity, the second-step liquidity check reads the reduced reserve balance and rejects repayment/update with ERR_EXCEEDED_LIQ.

This patch preserves the original pre-loan liquidity value and passes that snapshot into update-state-on-flash-loan, matching the accounting intent used by the single-step flashloan flow while keeping the split liquidation flow paired through a pending record.

## Validation
- git diff --check
- @hirosystems/clarinet-sdk initSimnet('./Clarinet-v2-0.toml', true) in an LF-normalized validation checkout loaded 124 contracts successfully.

Note: the existing Vitest liquidation suite currently calls initSimnet() without a manifest inside 	ests/borrow/tools/SimnetChecker.ts, so it falls back to Clarinet.toml, which references a missing contracts/borrow/deployment_mainnet/update-asset.clar file in this checkout before tests are collected.