### PR TITLE
fix(pool-borrow): snapshot pre-loan liquidity for flashloan-liquidation-step-2 (audit F-01)

### DIFF
--- a/onchain/contracts/borrow/production/pool/pool-borrow.clar
+++ b/onchain/contracts/borrow/production/pool/pool-borrow.clar
@@ -40,6 +40,7 @@
 (define-constant ERR_E_MODE_TYPE_MISMATCH (err u30029))
 (define-constant ERR_NO_ASSETS_USED_AS_COLLATERAL (err u30030))
 (define-constant ERR_MUST_ENABLE_ASSET_OF_E_MODE (err u30031))
+(define-constant ERR_NO_FLASHLOAN_SNAPSHOT (err u30032))
 
 
 (define-constant e-mode-disabled-type 0x00)
@@ -545,6 +546,12 @@
   )
 )
 
+;; F-01 fix: step-2 previously re-queried get-reserve-available-liquidity,
+;; which by that point reflects POST-loan liquidity (step-1 already
+;; transferred `amount` out). This map lets step-1 snapshot the true
+;; pre-loan liquidity so step-2 consumes that instead of re-querying.
+(define-map flashloan-liquidity-snapshot principal uint)
+
 (define-public (flashloan-liquidation-step-1
   (receiver principal)
   (asset <ft>)
@@ -565,6 +572,7 @@
     (asserts! (get is-active reserve-data) ERR_INACTIVE)
     (asserts! (not (get is-frozen reserve-data)) ERR_FROZEN)
 
+    (map-set flashloan-liquidity-snapshot (contract-of asset) available-liquidity-before)
     (try! (contract-call? .pool-0-reserve-v2-0 transfer-to-user asset receiver amount))
     (ok u0)
   )
@@ -576,7 +584,7 @@
   (amount uint)
   (flashloan-script <flash-loan>))
   (let  (
-    (available-liquidity-before (try! (contract-call? .pool-0-reserve-v2-0 get-reserve-available-liquidity asset)))
+    (available-liquidity-before (unwrap! (map-get? flashloan-liquidity-snapshot (contract-of asset)) ERR_NO_FLASHLOAN_SNAPSHOT))
     (total-fee-bps (try! (contract-call? .pool-0-reserve-v2-0 get-flashloan-fee-total (contract-of asset))))
     (protocol-fee-bps (try! (contract-call? .pool-0-reserve-v2-0 get-flashloan-fee-protocol (contract-of asset))))
     (amount-fee (/ (* amount total-fee-bps) u10000))
@@ -589,6 +597,8 @@
     (asserts! (get flashloan-enabled reserve-data) ERR_FLASHLOAN_DISABLED)
     (asserts! (get is-active reserve-data) ERR_INACTIVE)
     (asserts! (not (get is-frozen reserve-data)) ERR_FROZEN)
+
+    (map-delete flashloan-liquidity-snapshot (contract-of asset))
 
     (try!
       (contract-call? asset transfer


### PR DESCRIPTION
## Summary

Fixes audit finding **F-01** from the ClankOS Zest pool-borrow audit: https://gist.github.com/ClankOS/81d0c60d3378a9d37dea9fafb460a06d

`flashloan-liquidation-step-2` re-queried `get-reserve-available-liquidity` for its `available-liquidity-before` binding. By the time step-2 runs, step-1 has already called `transfer-to-user` and moved `amount` out of the pool — so the "before" value step-2 computes is actually **post-loan** liquidity, mislabeled as pre-loan. That corrupted value is passed straight into `update-state-on-flash-loan` as the baseline, and is also used in step-2's own `(asserts! (>= available-liquidity-before amount) ERR_EXCEEDED_LIQ)` check, which can spuriously fail on pools already near full utilization.

## Fix

Adds a `flashloan-liquidity-snapshot` map (keyed by asset principal, so concurrent flashloans on different assets don't collide):

- `flashloan-liquidation-step-1` snapshots the correctly-queried pre-loan `available-liquidity-before` into the map, before transferring `amount` out.
- `flashloan-liquidation-step-2` reads that snapshot instead of re-querying the reserve, then deletes the entry so it can't be read stale on a future flashloan.

No other behavior changes. Scoped to F-01 only — the audit's companion finding F-02 (no cross-tx binding between step-1/step-2 callers) is a separate, larger issue not addressed here.

## Testing

Diff is minimal (net +9 lines) and paren-balanced; no existing function signatures changed. I don't have write access to run the repo's test suite in this environment — a maintainer/CI run against the existing flashloan test fixtures is the fastest way to confirm no regression.

Filed as part of the "Fix-PR landing a finding from one of my 5 paid Stacks DeFi audits" bounty (2,000 sats, https://aibtc.com/bounties — bounty id `mqewgyvr5063fd520a70`), citing this PR + finding F-01.
